### PR TITLE
Compress null checks.

### DIFF
--- a/src/main/java/xbony2/huesosdewiki/HuesosDeWiki.java
+++ b/src/main/java/xbony2/huesosdewiki/HuesosDeWiki.java
@@ -81,12 +81,11 @@ public class HuesosDeWiki {
 					if(!isKeyDown){
 						isKeyDown = true;
 						Minecraft mc = Minecraft.getMinecraft();
-						Slot hovered = null;
 						GuiScreen currentScreen = mc.currentScreen;
-						if(currentScreen instanceof GuiContainer)
-							hovered = ((GuiContainer)currentScreen).getSlotUnderMouse();
-						
-						if(hovered != null){
+						if(currentScreen instanceof GuiContainer){
+							Slot hovered = ((GuiContainer)currentScreen).getSlotUnderMouse();
+							if (hovered == null)
+								return;
 							ItemStack itemstack = hovered.getStack();
 							if(!itemstack.isEmpty()){
 								String name = itemstack.getDisplayName();


### PR DESCRIPTION
getSlotUnderMouse() can return null. I am not certain, but I am guessing that this would be null when you press ; while hovering while not over a slot. I added a null check.
Slot hovered does not need to exist when it is not a GuiContainer, and itemstack only exists when it is a GuiContainer. Compressing these makes it a bit more concise and readable.