### PR TITLE
Fix reflection parameters when not in a dev environment

### DIFF
--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -1,5 +1,6 @@
 package xbony2.huesodewiki;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 import net.minecraft.item.Item;
@@ -8,6 +9,8 @@ import net.minecraft.item.crafting.Ingredient;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.oredict.OreDictionary;
+
+import javax.annotation.Nullable;
 
 public class Utils {
 	public static String getModName(ItemStack itemstack){
@@ -98,5 +101,26 @@ public class Utils {
 	 */
 	public static String formatInfoboxList(Iterable<String> strings){
 		return String.join("<br />", strings);
+	}
+
+	/**
+	 * @param clazz The class in which the Field is stored
+	 * @param mappedName The name of the field with MCP mappings
+	 * @param obfuscatedName The name of the field when obfuscated
+	 * @return The Field, or null if it couldn't find it. It will print the stacktrace if it is unable to find either.
+	 */
+	@Nullable
+	public static Field getField(Class clazz, String mappedName, String obfuscatedName){
+		Field field = null;
+		try{
+			field = clazz.getDeclaredField(obfuscatedName);
+		}catch(NoSuchFieldException obfException){
+			try{
+				field = clazz.getDeclaredField(mappedName);
+			}catch(NoSuchFieldException mappedNameException){
+				mappedNameException.printStackTrace();
+			}
+		}
+		return field;
 	}
 }

--- a/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
@@ -70,10 +70,12 @@ public class InfoboxCreator {
 			Item item = itemstack.getItem();
 			if(item instanceof ItemTool){
 				try{
-					Field field = ItemTool.class.getDeclaredField("attackDamage");
-					field.setAccessible(true);
-					return Utils.floatToString(field.getFloat((ItemTool)item) + 1.0f);
-				}catch(NoSuchFieldException | IllegalArgumentException | IllegalAccessException e){//Do not complain or you will be smote.
+					Field field = Utils.getField(ItemTool.class, "attackDamage", "field_77865_bY");
+					if(field != null){
+						field.setAccessible(true);
+						return Utils.floatToString(field.getFloat((ItemTool)item) + 1.0f);
+					}
+				}catch(IllegalArgumentException | IllegalAccessException e){//Do not complain or you will be smote.
 					e.printStackTrace();
 				}
 			}else if(item instanceof ItemSword){
@@ -91,10 +93,12 @@ public class InfoboxCreator {
 			Item item = itemstack.getItem();
 			if(item instanceof ItemTool){
 				try{
-					Field field = ItemTool.class.getDeclaredField("attackSpeed");
-					field.setAccessible(true);
-					return String.format("%.2g", field.getFloat((ItemTool)item) + 4.0f);
-				}catch(NoSuchFieldException | IllegalArgumentException | IllegalAccessException e){//Do not complain or you will be smote.
+					Field field = Utils.getField(ItemTool.class, "attackSpeed", "field_185065_c");
+					if(field != null){
+						field.setAccessible(true);
+						return String.format("%.2g", field.getFloat((ItemTool)item) + 4.0f);
+					}
+				}catch(IllegalArgumentException | IllegalAccessException e){//Do not complain or you will be smote.
 					e.printStackTrace();
 				}
 			}else if(item instanceof ItemSword){


### PR DESCRIPTION
Add new helper method for obtaining Fields, which requires the consumer to provide both the mapped field name (dev environment) and the obfuscated field name (actual game).
Close #42.
Close #43.

It is probably better to store the `Field`s in static fields somewhere after they are first obtained, for performance, but this is how the code was already set up so I left it like that.