### PR TITLE
Add effects parameter, resolves #39

### DIFF
--- a/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
@@ -62,6 +62,7 @@ public class InfoboxCreator {
 			ItemFood food = (ItemFood)itemstack.getItem();
 			return "{{Shanks|" + Integer.toString(food.getHealAmount(itemstack)) + "|" + Utils.floatToString(food.getSaturationModifier(itemstack)) + "}}";
 		}, ItemFood.class));
+		parameters.add(new EffectsParameter());
 		
 		parameters.add(new BasicInstanceOfParameter("armorrating", (itemstack) -> Integer.toString(((ItemArmor)itemstack.getItem()).damageReduceAmount), ItemArmor.class));
 		parameters.add(new ToughnessParameter());

--- a/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
@@ -62,8 +62,8 @@ public class InfoboxCreator {
 			ItemFood food = (ItemFood)itemstack.getItem();
 			return "{{Shanks|" + Integer.toString(food.getHealAmount(itemstack)) + "|" + Utils.floatToString(food.getSaturationModifier(itemstack)) + "}}";
 		}, ItemFood.class));
-		parameters.add(new EffectsParameter());
 		
+		parameters.add(new EffectsParameter());
 		parameters.add(new BasicInstanceOfParameter("armorrating", (itemstack) -> Integer.toString(((ItemArmor)itemstack.getItem()).damageReduceAmount), ItemArmor.class));
 		parameters.add(new ToughnessParameter());
 		parameters.add(new BasicInstanceOfParameter("damage", (itemstack) -> {

--- a/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
@@ -1,0 +1,75 @@
+package xbony2.huesodewiki.infobox.parameters;
+
+import net.minecraft.client.resources.I18n;
+import net.minecraft.item.ItemFood;
+import net.minecraft.item.ItemPotion;
+import net.minecraft.item.ItemStack;
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.potion.PotionUtils;
+import xbony2.huesodewiki.Utils;
+import xbony2.huesodewiki.api.infobox.IInfoboxParameter;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+public class EffectsParameter implements IInfoboxParameter {
+
+	@Override
+	public boolean canAdd(ItemStack itemstack){
+		return (itemstack.getItem() instanceof ItemFood && getEffect(itemstack) != null) || itemstack.getItem() instanceof ItemPotion;
+	}
+
+	@Override
+	public String getParameterName(){
+		return "effects";
+	}
+
+	@Override
+	public String getParameterText(ItemStack itemstack){
+		if(itemstack.getItem() instanceof ItemFood){
+			PotionEffect effect = getEffect(itemstack);
+
+			float chance = 1f;
+			try {
+				Field field = Utils.getField(ItemFood.class, "potionEffectProbability", "field_77858_cd");
+
+				if(field != null){
+					field.setAccessible(true);
+					chance = field.getFloat(itemstack.getItem());
+				}
+			}catch(IllegalArgumentException | IllegalAccessException e){
+				e.printStackTrace();
+			}
+			return formatEffect(effect, chance);
+		}else{
+			List<PotionEffect> effects = PotionUtils.getEffectsFromStack(itemstack);
+			StringBuilder str = new StringBuilder();
+			for(PotionEffect effect : effects){
+				str.append(formatEffect(effect, 1f));
+			}
+			return str.toString();
+		}
+	}
+
+	private PotionEffect getEffect(ItemStack itemstack){
+		try {
+			Field field = Utils.getField(ItemFood.class, "potionId", "field_77851_ca");
+
+			if(field != null){
+				field.setAccessible(true);
+				return (PotionEffect) field.get(itemstack.getItem());
+			}
+		}catch(IllegalArgumentException | IllegalAccessException e){
+			e.printStackTrace();
+		}
+		return null;
+	}
+
+	private String formatEffect(PotionEffect effect, float chance){
+		String s = "{{Effect|" + I18n.format(effect.getEffectName()) + "|" + Integer.toString(effect.getDuration()) + "|" + Integer.toString(effect.getAmplifier());
+		if(chance != 1f)
+			s += "|" + Utils.floatToString((1000.0f * chance) / 10f); //round to one decimal
+		s += "}}";
+		return s;
+	}
+}

--- a/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
@@ -44,9 +44,7 @@ public class EffectsParameter implements IInfoboxParameter {
 		}else{
 			List<PotionEffect> effects = PotionUtils.getEffectsFromStack(itemstack);
 			StringBuilder str = new StringBuilder();
-			for(PotionEffect effect : effects){
-				str.append(formatEffect(effect, 1f));
-			}
+			effects.forEach(effect -> str.append(formatEffect(effect, 1f)));
 			return str.toString();
 		}
 	}

--- a/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
@@ -49,7 +49,7 @@ public class EffectsParameter implements IInfoboxParameter {
 		}
 	}
 
-	private PotionEffect getEffect(ItemStack itemstack){
+	private static PotionEffect getEffect(ItemStack itemstack){
 		try {
 			Field field = Utils.getField(ItemFood.class, "potionId", "field_77851_ca");
 
@@ -63,7 +63,7 @@ public class EffectsParameter implements IInfoboxParameter {
 		return null;
 	}
 
-	private String formatEffect(PotionEffect effect, float chance){
+	private static String formatEffect(PotionEffect effect, float chance){
 		String s = "{{Effect|" + I18n.format(effect.getEffectName()) + "|" + Integer.toString(effect.getDuration()) + "|" + Integer.toString(effect.getAmplifier());
 		if(chance != 1f)
 			s += "|" + Utils.floatToString((1000.0f * chance) / 10f); //round to one decimal


### PR DESCRIPTION
Adds the effects parameter, which retrieves the effect from items with potion effects (like rotten flesh, TF hydra chops, etc.) and from potions (though only items extending vanilla potion bottles). Items manually applying potion effects (like golden apples) are not affected - I think that would require some fake player trickery which I don't really think is worth it. 

I hope the code style is good enough for you this time! :P 