### PR TITLE
Eliminate complicated redundancy in renderTickEvent

### DIFF
--- a/src/main/java/xbony2/huesodewiki/HuesoDeWiki.java
+++ b/src/main/java/xbony2/huesodewiki/HuesoDeWiki.java
@@ -84,13 +84,11 @@ public class HuesoDeWiki {
 		 */
 		@Nonnull
 		private ItemStack getHoveredItemStack(){
-			Minecraft mc = Minecraft.getMinecraft();
-			GuiScreen currentScreen = mc.currentScreen;
+			GuiScreen currentScreen = Minecraft.getMinecraft().currentScreen;
 			if(currentScreen instanceof GuiContainer){
 				Slot hovered = ((GuiContainer)currentScreen).getSlotUnderMouse();
-				if(hovered != null){
+				if(hovered != null)
 					return hovered.getStack();
-				}
 			}
 			return ItemStack.EMPTY;
 		}

--- a/src/main/java/xbony2/huesodewiki/HuesoDeWiki.java
+++ b/src/main/java/xbony2/huesodewiki/HuesoDeWiki.java
@@ -1,19 +1,14 @@
 package xbony2.huesodewiki;
 
-import java.awt.Toolkit;
-import java.awt.datatransfer.StringSelection;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import org.lwjgl.input.Keyboard;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
-import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.settings.KeyBinding;
-import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.common.MinecraftForge;
@@ -27,8 +22,6 @@ import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.common.gameevent.TickEvent.RenderTickEvent;
 import xbony2.huesodewiki.compat.Compat;
 import xbony2.huesodewiki.recipe.RecipeCreator;
-
-import javax.annotation.Nonnull;
 
 @Mod(modid = HuesoDeWiki.MODID, version = HuesoDeWiki.VERSION, clientSideOnly = true)
 public class HuesoDeWiki {
@@ -77,43 +70,19 @@ public class HuesoDeWiki {
 	}
 	
 	private class RenderTickEventEventHanlder {
-		/**
-		 * @return The ItemStack that the player is currently hovering over. If they are hovering over an empty slot,
-		 * 		   are not hovering over a slot or they are hovering over a slot in a non-supported Gui, returns an
-		 * 		   empty ItemStack.
-		 */
-		@Nonnull
-		private ItemStack getHoveredItemStack(){
-			GuiScreen currentScreen = Minecraft.getMinecraft().currentScreen;
-			if(currentScreen instanceof GuiContainer){
-				Slot hovered = ((GuiContainer)currentScreen).getSlotUnderMouse();
-				if(hovered != null)
-					return hovered.getStack();
-			}
-			return ItemStack.EMPTY;
-		}
-
-		/**
-		 * Adds the provided string to the system clipboard
-		 * @param toCopy The string to add to the clipboard
-		 */
-		private void copyString(String toCopy){
-			Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(toCopy), null);
-		}
-
 		@SubscribeEvent
 		public void renderTickEvent(RenderTickEvent event){
 			if(event.phase == Phase.START){
 				if(Keyboard.isKeyDown(copyPageKey.getKeyCode())){
 					if(!isCopyPageKeyDown){
 						isCopyPageKeyDown = true;
-						ItemStack itemstack = getHoveredItemStack();
+						ItemStack itemstack = Utils.getHoveredItemStack();
 						if(!itemstack.isEmpty()){
 							if(GuiScreen.isCtrlKeyDown()){
-								copyString(RecipeCreator.createRecipes(itemstack));
+								Utils.copyString(RecipeCreator.createRecipes(itemstack));
 								Minecraft.getMinecraft().ingameGUI.getChatGUI().printChatMessage(new TextComponentTranslation("msg.copiedrecipe", itemstack.getDisplayName()));
 							}else{
-								copyString(PageCreator.createPage(itemstack));
+								Utils.copyString(PageCreator.createPage(itemstack));
 								Minecraft.getMinecraft().ingameGUI.getChatGUI().printChatMessage(new TextComponentTranslation("msg.copiedpage", itemstack.getDisplayName()));
 							}
 						}else
@@ -125,9 +94,9 @@ public class HuesoDeWiki {
 				if(Keyboard.isKeyDown(copyNameKey.getKeyCode())){
 					if(!isCopyNameKeyDown){
 						isCopyNameKeyDown = true;
-						ItemStack itemstack = getHoveredItemStack();
+						ItemStack itemstack = Utils.getHoveredItemStack();
 						if(!itemstack.isEmpty())
-							copyString(itemstack.getDisplayName());
+							Utils.copyString(itemstack.getDisplayName());
 					}
 				}else
 					isCopyNameKeyDown = false;

--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -1,8 +1,14 @@
 package xbony2.huesodewiki;
 
+import java.awt.*;
+import java.awt.datatransfer.StringSelection;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
@@ -10,6 +16,7 @@ import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.oredict.OreDictionary;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class Utils {
@@ -122,5 +129,29 @@ public class Utils {
 			}
 		}
 		return field;
+	}
+
+	/**
+	 * @return The ItemStack that the player is currently hovering over. If they are hovering over an empty slot,
+	 * 		   are not hovering over a slot or they are hovering over a slot in a non-supported Gui, returns an
+	 * 		   empty ItemStack.
+	 */
+	@Nonnull
+	public static ItemStack getHoveredItemStack(){
+		GuiScreen currentScreen = Minecraft.getMinecraft().currentScreen;
+		if(currentScreen instanceof GuiContainer){
+			Slot hovered = ((GuiContainer)currentScreen).getSlotUnderMouse();
+			if(hovered != null)
+				return hovered.getStack();
+		}
+		return ItemStack.EMPTY;
+	}
+
+	/**
+	 * Adds the provided string to the system clipboard
+	 * @param toCopy The string to add to the clipboard
+	 */
+	public static void copyString(String toCopy){
+		Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(toCopy), null);
 	}
 }


### PR DESCRIPTION
Move the Gui checking to its own method, as it is used twice. This will make it easier to support additional Gui types (thinking about #38), and if necessary fix issues in the future with it because it will require one change rather than two identical changes.
Move the copying code to its own method, because it is a very long string of method calls. copyString is a much more readable way of thinking about it if you do not care about *how* the string is copied.
Switch the isCtrlKeyDown check to be non-inversed, since it is easier to think about that else clause that way.