### PR TITLE
Update Forge to 2624 and MCP mappings to tonights nightly

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-forgeVersion=1.12.2-14.23.1.2555
-mappingsVersion=snapshot_20171210
+forgeVersion=1.12.2-14.23.2.2624
+mappingsVersion=snapshot_20180303
 teslaVersion=1.12.2-1.0.63
 
 newHuesoDeWiki=1.3.4a


### PR DESCRIPTION
JEI needs a version newer than 2555, so I updated both Forge and the mappings to nightly so that I can work on JEI integration (#38). Fortunately, nothing else needed to be fixed for it to compile.