### PR TITLE
Migrate reflection to ObfuscationReflectionHelper

### DIFF
--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -2,7 +2,6 @@ package xbony2.huesodewiki;
 
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
-import java.lang.reflect.Field;
 import java.util.List;
 
 import net.minecraft.client.Minecraft;
@@ -16,7 +15,6 @@ import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 public class Utils {
 	public static String getModName(String modid){
@@ -111,27 +109,6 @@ public class Utils {
 	 */
 	public static String formatInfoboxList(Iterable<String> strings){
 		return String.join("<br />", strings);
-	}
-
-	/**
-	 * @param clazz The class in which the Field is stored
-	 * @param mappedName The name of the field with MCP mappings
-	 * @param obfuscatedName The name of the field when obfuscated
-	 * @return The Field, or null if it couldn't find it. It will print the stacktrace if it is unable to find either.
-	 */
-	@Nullable
-	public static Field getField(Class clazz, String mappedName, String obfuscatedName){
-		Field field = null;
-		try{
-			field = clazz.getDeclaredField(obfuscatedName);
-		}catch(NoSuchFieldException obfException){
-			try{
-				field = clazz.getDeclaredField(mappedName);
-			}catch(NoSuchFieldException mappedNameException){
-				mappedNameException.printStackTrace();
-			}
-		}
-		return field;
 	}
 
 	/**

--- a/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
@@ -1,6 +1,5 @@
 package xbony2.huesodewiki.infobox;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,6 +15,7 @@ import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
 import net.minecraft.item.ItemTool;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import xbony2.huesodewiki.Utils;
 import xbony2.huesodewiki.api.infobox.BasicInstanceOfParameter;
 import xbony2.huesodewiki.api.infobox.IInfoboxParameter;
@@ -68,17 +68,9 @@ public class InfoboxCreator {
 		parameters.add(new ToughnessParameter());
 		parameters.add(new BasicInstanceOfParameter("damage", (itemstack) -> {
 			Item item = itemstack.getItem();
-			if(item instanceof ItemTool){
-				try{
-					Field field = Utils.getField(ItemTool.class, "attackDamage", "field_77865_bY");
-					if(field != null){
-						field.setAccessible(true);
-						return Utils.floatToString(field.getFloat((ItemTool)item) + 1.0f);
-					}
-				}catch(IllegalArgumentException | IllegalAccessException e){//Do not complain or you will be smote.
-					e.printStackTrace();
-				}
-			}else if(item instanceof ItemSword){
+			if(item instanceof ItemTool)
+				return Utils.floatToString(ObfuscationReflectionHelper.getPrivateValue(ItemTool.class, (ItemTool) item, "field_77865_bY")); //attackDamage
+			else if(item instanceof ItemSword){
 				Multimap<String, AttributeModifier> multimap = ((ItemSword)item).getItemAttributeModifiers(EntityEquipmentSlot.MAINHAND);
 				float damage = 1.0f; //default
 				for(String name : multimap.keySet())
@@ -91,17 +83,9 @@ public class InfoboxCreator {
 		}, ItemTool.class, ItemSword.class));
 		parameters.add(new BasicInstanceOfParameter("aspeed", (itemstack) -> {
 			Item item = itemstack.getItem();
-			if(item instanceof ItemTool){
-				try{
-					Field field = Utils.getField(ItemTool.class, "attackSpeed", "field_185065_c");
-					if(field != null){
-						field.setAccessible(true);
-						return String.format("%.2g", field.getFloat((ItemTool)item) + 4.0f);
-					}
-				}catch(IllegalArgumentException | IllegalAccessException e){//Do not complain or you will be smote.
-					e.printStackTrace();
-				}
-			}else if(item instanceof ItemSword){
+			if(item instanceof ItemTool)
+				return Utils.floatToString(ObfuscationReflectionHelper.getPrivateValue(ItemTool.class, (ItemTool) item, "field_185065_c")); //attackSpeed
+			else if(item instanceof ItemSword){
 				Multimap<String, AttributeModifier> multimap = ((ItemSword)item).getItemAttributeModifiers(EntityEquipmentSlot.MAINHAND);
 				float speed = 4.0f; //default
 				for(String name : multimap.keySet())
@@ -113,7 +97,7 @@ public class InfoboxCreator {
 			}
 			return "?";
 		}, ItemTool.class, ItemSword.class));
-		parameters.add(new BasicInstanceOfParameter("durability", (itemstack) -> Utils.floatToString(((ItemTool)itemstack.getItem()).getMaxDamage(itemstack) + 1), ItemTool.class));
+		parameters.add(new BasicInstanceOfParameter("durability", (itemstack) -> Utils.floatToString(itemstack.getItem().getMaxDamage(itemstack) + 1), ItemTool.class));
 		parameters.add(new EnchantabilityParameter());
 		parameters.add(new MiningLevelParameter());
 		parameters.add(new MiningSpeedParameter());

--- a/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/parameters/EffectsParameter.java
@@ -6,10 +6,10 @@ import net.minecraft.item.ItemPotion;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.potion.PotionUtils;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import xbony2.huesodewiki.Utils;
 import xbony2.huesodewiki.api.infobox.IInfoboxParameter;
 
-import java.lang.reflect.Field;
 import java.util.List;
 
 public class EffectsParameter implements IInfoboxParameter {
@@ -28,18 +28,7 @@ public class EffectsParameter implements IInfoboxParameter {
 	public String getParameterText(ItemStack itemstack){
 		if(itemstack.getItem() instanceof ItemFood){
 			PotionEffect effect = getEffect(itemstack);
-
-			float chance = 1f;
-			try {
-				Field field = Utils.getField(ItemFood.class, "potionEffectProbability", "field_77858_cd");
-
-				if(field != null){
-					field.setAccessible(true);
-					chance = field.getFloat(itemstack.getItem());
-				}
-			}catch(IllegalArgumentException | IllegalAccessException e){
-				e.printStackTrace();
-			}
+			float chance = ObfuscationReflectionHelper.getPrivateValue(ItemFood.class, (ItemFood) itemstack.getItem(), "field_77858_cd"); //potionEffectProbability
 			return formatEffect(effect, chance);
 		}else{
 			List<PotionEffect> effects = PotionUtils.getEffectsFromStack(itemstack);
@@ -50,17 +39,7 @@ public class EffectsParameter implements IInfoboxParameter {
 	}
 
 	private static PotionEffect getEffect(ItemStack itemstack){
-		try {
-			Field field = Utils.getField(ItemFood.class, "potionId", "field_77851_ca");
-
-			if(field != null){
-				field.setAccessible(true);
-				return (PotionEffect) field.get(itemstack.getItem());
-			}
-		}catch(IllegalArgumentException | IllegalAccessException e){
-			e.printStackTrace();
-		}
-		return null;
+		return ObfuscationReflectionHelper.getPrivateValue(ItemFood.class, (ItemFood) itemstack.getItem(), "field_77851_ca"); //potionId
 	}
 
 	private static String formatEffect(PotionEffect effect, float chance){

--- a/src/main/java/xbony2/huesodewiki/infobox/parameters/MiningSpeedParameter.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/parameters/MiningSpeedParameter.java
@@ -3,10 +3,9 @@ package xbony2.huesodewiki.infobox.parameters;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemTool;
+import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import xbony2.huesodewiki.Utils;
 import xbony2.huesodewiki.api.infobox.IInfoboxParameter;
-
-import java.lang.reflect.Field;
 
 public class MiningSpeedParameter implements IInfoboxParameter {
 	
@@ -22,17 +21,7 @@ public class MiningSpeedParameter implements IInfoboxParameter {
 
 	@Override
 	public String getParameterText(ItemStack itemstack) {
-		try {
-			Field field = Utils.getField(ItemTool.class, "toolMaterial", "field_77862_b");
-			
-			if(field != null){
-				field.setAccessible(true);
-				return Utils.floatToString(((Item.ToolMaterial) field.get(itemstack.getItem())).getEfficiency());
-			}
-		}catch(IllegalArgumentException | IllegalAccessException e){
-			e.printStackTrace();
-		}
-		
-		return "?";
+		Item.ToolMaterial material = ObfuscationReflectionHelper.getPrivateValue(ItemTool.class, (ItemTool) itemstack.getItem(), "field_77862_b"); //toolMaterial
+		return Utils.floatToString(material.getEfficiency()); //toolMaterial
 	}
 }


### PR DESCRIPTION
Simplifies reflection code and keeps it mappings-independent.
There's no need to copypaste the same snippet whenever you need to reflect into something.

The one advantage of the previous approach was the possibility of caching fields, but we didn't do that at all and the code doesn't run very often anyways... and if we decide to do that, we can just use ReflectionHelper's `findField` instead (and there's a pull request to Forge waiting that would add methods for that to the obfuscation helper).

Also, you no longer have a reason to tell people to not complain about those catch blocks. 