### PR TITLE
Fix oredict wildcards causing recipe ingredients to be ignored

### DIFF
--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -7,9 +7,11 @@ import java.util.List;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.oredict.OreDictionary;
@@ -71,11 +73,18 @@ public class Utils {
 				String potentialEntry = OreDictionary.getOreName(ids[i]);
 				List<ItemStack> potentialCognate = OreDictionary.getOres(potentialEntry);
 				
-				boolean isEqual = potentialCognate.size() == list.length;
+				NonNullList<ItemStack> potentialCognateExploded = NonNullList.create();
+				for(ItemStack itemStack : potentialCognate)
+					if(itemStack.getMetadata() == OreDictionary.WILDCARD_VALUE)
+						itemStack.getItem().getSubItems(CreativeTabs.SEARCH, potentialCognateExploded);
+					else
+						potentialCognateExploded.add(itemStack);
+					
+				boolean isEqual = potentialCognateExploded.size() == list.length;
 				
 				if(isEqual) //so far, that is
 					for(int j = 0; j < list.length; j++)
-						if(potentialCognate.get(j).getItem() != list[j].getItem() && potentialCognate.get(j).getItemDamage() != list[j].getItemDamage())
+						if(potentialCognateExploded.get(j).getItem() != list[j].getItem() && potentialCognateExploded.get(j).getItemDamage() != list[j].getItemDamage())
 							isEqual = false;
 				
 				if(isEqual)


### PR DESCRIPTION
Fixes #25. Now `blockGlass` oredict will actually work!

The issue? `OreIngredient#getMatchingStacks` returns an exploded list of matching items - one of the effects is turning wildcard metadata stacks into all the stacks of that item appearing in the creative menu. That list was directly compared to OreDictionary's list of ore stacks - except that one can contain wildcard metadata stacks. 

Why did `blockGlass` not work? It contains `minecraft:glass` meta 0 and `minecraft:stained_glass` meta 32767. The oredict lookup method tried to compare a list of 2 items and 17 items to see if they are the same thing, they did not match, so it gave up. I found this detail with a little bit of debugger use.

<details><summary>Code used to reproduce this</summary><p>

```java
package xbony2.huesodewiki;

import net.minecraft.init.Items;
import net.minecraft.item.ItemStack;
import net.minecraft.item.crafting.IRecipe;
import net.minecraft.item.crafting.Ingredient;
import net.minecraft.item.crafting.ShapedRecipes;
import net.minecraft.util.NonNullList;
import net.minecraft.util.ResourceLocation;
import net.minecraftforge.event.RegistryEvent;
import net.minecraftforge.fml.common.Mod;
import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
import net.minecraftforge.oredict.OreIngredient;

@Mod.EventBusSubscriber(modid = HuesoDeWiki.MODID)
public class RecipeTest {
	@SubscribeEvent
	public static void testRecipe(RegistryEvent.Register<IRecipe> event) {
		IRecipe recipe = new ShapedRecipes("hueso", 1, 2, 
				NonNullList.from(Ingredient.EMPTY, 
				new OreIngredient("blockGlass"), 
				new OreIngredient("blockGlass")), 
				new ItemStack(Items.COOKIE));
		recipe.setRegistryName(new ResourceLocation(HuesoDeWiki.MODID, "test"));
		event.getRegistry().register(recipe);
	}
}
```
</p></details>
The solution is to mirror the exploding of the recipes in the oredict lookup. I have tested this a bit on other vanilla recipes and no side effects of this fix seem to occur.