### PR TITLE
Make parameters for blocks metadata sensitive

### DIFF
--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -3,7 +3,10 @@ package xbony2.huesodewiki;
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.util.List;
+import javax.annotation.Nonnull;
 
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -15,8 +18,6 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.oredict.OreDictionary;
-
-import javax.annotation.Nonnull;
 
 public class Utils {
 	public static String getModName(String modid){
@@ -109,6 +110,15 @@ public class Utils {
 		if(ret.endsWith(".0"))
 				ret = ret.replaceAll(".0$", "");
 		return ret;
+	}
+
+	public static IBlockState stackToBlockState(ItemStack itemstack){
+		Block b = Block.getBlockFromItem(itemstack.getItem());
+		try {
+			return b.getStateFromMeta(itemstack.getMetadata());
+		}catch(Exception e){
+			return b.getDefaultState();
+		}
 	}
 
 	/**

--- a/src/main/java/xbony2/huesodewiki/infobox/parameters/LuminanceParameter.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/parameters/LuminanceParameter.java
@@ -3,6 +3,7 @@ package xbony2.huesodewiki.infobox.parameters;
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import xbony2.huesodewiki.Utils;
 import xbony2.huesodewiki.api.infobox.IInfoboxParameter;
 
 public class LuminanceParameter implements IInfoboxParameter {
@@ -11,9 +12,12 @@ public class LuminanceParameter implements IInfoboxParameter {
 	public boolean canAdd(ItemStack itemstack){
 		if(itemstack.getItem() instanceof ItemBlock){
 			Block block = ((ItemBlock) itemstack.getItem()).getBlock();
-			return block.getLightValue(block.getDefaultState(), null, null) > 0;
+			try {
+				return block.getLightValue(Utils.stackToBlockState(itemstack), null, null) > 0;
+			}catch(Exception e){
+				return false;
+			}
 		}
-		
 		return false;
 	}
 
@@ -25,6 +29,6 @@ public class LuminanceParameter implements IInfoboxParameter {
 	@Override
 	public String getParameterText(ItemStack itemstack){
 		Block block = ((ItemBlock) itemstack.getItem()).getBlock();
-		return Integer.toString(block.getLightValue(block.getDefaultState(), null, null));
+		return Integer.toString(block.getLightValue(Utils.stackToBlockState(itemstack), null, null));
 	}
 }

--- a/src/main/java/xbony2/huesodewiki/infobox/parameters/types/TEntityType.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/parameters/types/TEntityType.java
@@ -2,6 +2,7 @@ package xbony2.huesodewiki.infobox.parameters.types;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.ItemStack;
+import xbony2.huesodewiki.Utils;
 import xbony2.huesodewiki.api.infobox.type.IType;
 
 public class TEntityType implements IType {
@@ -18,6 +19,6 @@ public class TEntityType implements IType {
 	@Override
 	public boolean isApplicable(ItemStack itemstack){
 		Block block = Block.getBlockFromItem(itemstack.getItem());
-		return block.hasTileEntity(block.getDefaultState());
+		return block.hasTileEntity(Utils.stackToBlockState(itemstack));
 	}
 }


### PR DESCRIPTION
Some blocks have different light values and tile entities depending on the metadata on the block. This PR changes it so that it doesn't use the default state of the block for that.

Also, fixed a crash on blocks with world/pos-sensitive light values - we are not really supposed to pass nulls there (and the tile entity param was already try-catched). Of course this should be done with a world, but I don't think it is worth messing with fake worlds for this...