### PR TITLE
Rewrite workbench recipe dumping

### DIFF
--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -156,4 +156,11 @@ public class Utils {
 		if(HuesoDeWiki.printOutputToLog) 
 			HuesoDeWiki.LOGGER.info("Generated text:\n" + toCopy);
 	}
+
+	/**
+	 * Returns a letter corresponding to the specified number. (eg. 1 will return 'A')
+	 */
+	public static char getAlphabetLetter(int index){
+		return (char)(index + 'A' - 1);
+	}
 }

--- a/src/main/java/xbony2/huesodewiki/command/CommandDumpStructure.java
+++ b/src/main/java/xbony2/huesodewiki/command/CommandDumpStructure.java
@@ -211,12 +211,12 @@ public class CommandDumpStructure extends CommandBase {
 
 		@Override
 		public String toString(){
-			StringBuilder builder = new StringBuilder("|").append(getAlphabetLetter(y));
+			StringBuilder builder = new StringBuilder("|").append(Utils.getAlphabetLetter(y));
 			
 			if(reverse)
-				builder.append(getAlphabetLetter(z)).append(x);
+				builder.append(Utils.getAlphabetLetter(z)).append(x);
 			else
-				builder.append(getAlphabetLetter(x)).append(z);
+				builder.append(Utils.getAlphabetLetter(x)).append(z);
 			
 			builder.append('=');
 
@@ -253,10 +253,6 @@ public class CommandDumpStructure extends CommandBase {
 			return getListOfStringsMatchingLastWord(args, "true", "false");
 		
 		return Collections.emptyList();
-	}
-
-	private static char getAlphabetLetter(int index){
-		return (char)(index + 'A' - 1);
 	}
 
 	private static String outputFluid(FluidStack fluidstack){

--- a/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
+++ b/src/main/java/xbony2/huesodewiki/infobox/InfoboxCreator.java
@@ -74,7 +74,7 @@ public class InfoboxCreator {
 				Multimap<String, AttributeModifier> multimap = ((ItemSword)item).getItemAttributeModifiers(EntityEquipmentSlot.MAINHAND);
 				float damage = 1.0f; //default
 				for(String name : multimap.keySet())
-					if(name == SharedMonsterAttributes.ATTACK_DAMAGE.getName())
+					if(name.equals(SharedMonsterAttributes.ATTACK_DAMAGE.getName()))
 						for(AttributeModifier modifier : multimap.get(name))
 							damage += modifier.getAmount();
 				return Utils.floatToString(damage);
@@ -89,7 +89,7 @@ public class InfoboxCreator {
 				Multimap<String, AttributeModifier> multimap = ((ItemSword)item).getItemAttributeModifiers(EntityEquipmentSlot.MAINHAND);
 				float speed = 4.0f; //default
 				for(String name : multimap.keySet())
-					if(name == SharedMonsterAttributes.ATTACK_SPEED.getName())
+					if(name.equals(SharedMonsterAttributes.ATTACK_SPEED.getName()))
 						for(AttributeModifier modifier : multimap.get(name))
 							speed += modifier.getAmount();
 				

--- a/src/main/java/xbony2/huesodewiki/recipe/RecipeCreator.java
+++ b/src/main/java/xbony2/huesodewiki/recipe/RecipeCreator.java
@@ -22,7 +22,7 @@ public class RecipeCreator {
 		recipes.forEach((recipe) -> {
 			String potentialRecipes = recipe.getRecipes(itemstack);
 			
-			if(potentialRecipes != null && potentialRecipes != "")
+			if(potentialRecipes != null && !potentialRecipes.equals(""))
 				ret.append(potentialRecipes);
 		});
 		

--- a/src/main/java/xbony2/huesodewiki/recipe/recipes/CraftingRecipe.java
+++ b/src/main/java/xbony2/huesodewiki/recipe/recipes/CraftingRecipe.java
@@ -1,10 +1,5 @@
 package xbony2.huesodewiki.recipe.recipes;
 
-import static xbony2.huesodewiki.Utils.outputItem;
-import static xbony2.huesodewiki.Utils.outputIngredient;
-import static xbony2.huesodewiki.Utils.outputItemOutput;
-import static xbony2.huesodewiki.Utils.outputOreDictionaryEntry;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -13,207 +8,80 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.item.crafting.Ingredient;
-import net.minecraft.item.crafting.ShapedRecipes;
-import net.minecraft.item.crafting.ShapelessRecipes;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.common.crafting.IShapedRecipe;
 import net.minecraftforge.oredict.OreIngredient;
-import net.minecraftforge.oredict.ShapedOreRecipe;
-import net.minecraftforge.oredict.ShapelessOreRecipe;
+import xbony2.huesodewiki.Utils;
 import xbony2.huesodewiki.api.IWikiRecipe;
 
 public class CraftingRecipe implements IWikiRecipe {
-	public static String getShapedLocation(int height, int width){
-		return ((char)(width + 64)) + "" + height;
-	}
-	
-	public static String getShapelessLocation(int index, int max){
-		if(max > 6)
-			switch(index){
-			case 0:
-				return "A1";
-			case 1:
-				return "B1";
-			case 2:
-				return "C1";
-			case 3:
-				return "A2";
-			case 4:
-				return "B2";
-			case 5:
-				return "C2";
-			case 6:
-				return "A3";
-			case 7:
-				return "B3";
-			case 8:
-				return "C3";
-			}
-		else
-			switch(index){
-			case 0:
-				return "A1";
-			case 1:
-				return "B1";
-			case 2:
-				return "A2";
-			case 3:
-				return "B2";
-			case 4:
-				return "A3";
-			case 5:
-				return "B3";
-			}
-		return null;
-	}
 
 	@Override
 	public String getRecipes(ItemStack itemstack){
 		StringBuilder ret = new StringBuilder();
+		List<IRecipe> recipes = gatherRecipes(itemstack);
+
+		if(recipes.isEmpty())
+			return "";
+
+		for(Iterator<IRecipe> iterator = recipes.iterator(); iterator.hasNext(); ){
+			IRecipe recipe = iterator.next();
+			ret.append(outputRecipe(recipe));
+			if(iterator.hasNext())
+				ret.append('\n');
+		}
+
+		return ret.toString();
+	}
+
+	public List<IRecipe> gatherRecipes(ItemStack itemstack){
 		List<IRecipe> recipes = new ArrayList<>();
-		
+
 		CraftingManager.REGISTRY.forEach((recipe) -> {
 			if(recipe.getRecipeOutput().isItemEqual(itemstack))
 				recipes.add(recipe);
 		});
-		
-		if(!recipes.isEmpty())
-			for(Iterator<IRecipe> iterator = recipes.iterator(); iterator.hasNext();){
-				IRecipe recipe = iterator.next();
-				
-				if(recipe instanceof ShapedRecipes){
-					ShapedRecipes shapedrecipe = (ShapedRecipes)recipe;
-					ret.append("{{Cg/Crafting Table\n");
-					
-					int maxHeight = shapedrecipe.recipeHeight;
-					int maxWidth = shapedrecipe.recipeWidth;
-					
-					for(int h = 1; h <= maxHeight; h++){
-						for(int w = 1; w <= maxWidth; w++){
-							Ingredient component = Ingredient.EMPTY;
-							
-							switch(h){
-							case 1:
-								component = shapedrecipe.recipeItems.get(w - 1);
-								break;
-							case 2:
-								component = shapedrecipe.recipeItems.get(maxWidth + (w - 1));
-								break;
-							case 3:
-								component = shapedrecipe.recipeItems.get((maxWidth * 2) + (w - 1));
-								break;
-							}
-							
-							if(component != Ingredient.EMPTY)
-								if(!(component instanceof OreIngredient)) //Forge injects Vanilla
-									ret.append('|').append(getShapedLocation(h, w)).append('=').append(outputIngredient(component)).append('\n');
-								else{
-									String entry = outputOreDictionaryEntry(component.getMatchingStacks());
-								
-									if(entry != null)
-										ret.append('|').append(getShapedLocation(h, w)).append('=').append(entry).append('\n');
-							}
-						}
-					}
-					
-					ret.append("|O=").append(outputItemOutput(shapedrecipe.getRecipeOutput())).append('\n');
-					ret.append("}}").append('\n');
-					
-					if(iterator.hasNext())
-						ret.append('\n');
-				}else if(recipe instanceof ShapedOreRecipe){
-					ShapedOreRecipe shapedrecipe = (ShapedOreRecipe)recipe;
-					ret.append("{{Cg/Crafting Table\n");
-					
-					int maxHeight = shapedrecipe.getRecipeHeight();
-					int maxWidth = shapedrecipe.getRecipeWidth();
-					
-					for(int h = 1; h <= maxHeight; h++){
-						for(int w = 1; w <= maxWidth; w++){
-							Ingredient component = Ingredient.EMPTY;
-							
-							switch(h){
-							case 1:
-								component = shapedrecipe.getIngredients().get(w - 1);
-								
-								break;
-							case 2:
-								component = shapedrecipe.getIngredients().get(maxWidth + (w - 1));
-								break;
-							case 3:
-								component = shapedrecipe.getIngredients().get((maxWidth * 2) + (w - 1));
-								break;
-							}
-							
-							if(component != Ingredient.EMPTY)
-								if(!(component instanceof OreIngredient))
-									ret.append('|').append(getShapedLocation(h, w)).append('=').append(outputIngredient(component)).append('\n');
-								else{
-									String entry = outputOreDictionaryEntry(component.getMatchingStacks());
-								
-									if(entry != null)
-										ret.append('|').append(getShapedLocation(h, w)).append('=').append(entry).append('\n');
-								}
-						}
-					}
-					
-					ret.append("|O=").append(outputItemOutput(shapedrecipe.getRecipeOutput())).append('\n');
-					ret.append("}}\n");
-					
-					if(iterator.hasNext())
-						ret.append('\n');
-				}else if(recipe instanceof ShapelessRecipes){
-					ShapelessRecipes shapelessrecipe = (ShapelessRecipes)recipe;
-					ret.append("{{Cg/Crafting Table\n");
-					
-					List<Ingredient> recipeItems = shapelessrecipe.recipeItems;
-					
-					for(int i = 0; i < recipeItems.size(); i++){
-						Ingredient component = recipeItems.get(i);
-						
-						if(component != Ingredient.EMPTY)
-							if(!(component instanceof OreIngredient))
-								ret.append('|').append(getShapelessLocation(i, recipeItems.size())).append('=').append(outputIngredient(component)).append('\n');
-							else{
-								String entry = outputOreDictionaryEntry(component.getMatchingStacks());
-								
-								if(entry != null)
-									ret.append('|').append(getShapelessLocation(i, recipeItems.size())).append('=').append(entry).append('\n');
-							}
-					}
-					
-					ret.append("|O=").append(outputItemOutput(shapelessrecipe.getRecipeOutput())).append('\n');
-					ret.append("|shapeless=true\n");
-					ret.append("}}\n");
-					
-					if(iterator.hasNext())
-						ret.append('\n');
-				}else if(recipe instanceof ShapelessOreRecipe){
-					ShapelessOreRecipe shapelessrecipe = (ShapelessOreRecipe)recipe;
-					ret.append("{{Cg/Crafting Table\n");
-					
-					List<Ingredient> recipeItems = shapelessrecipe.getIngredients();
-					
-					for(int i = 0; i < recipeItems.size(); i++){
-						Ingredient component = recipeItems.get(i);
-						
-						if(component != Ingredient.EMPTY)
-							if(!(component instanceof OreIngredient))
-								ret.append('|').append(getShapelessLocation(i, recipeItems.size())).append('=').append(outputIngredient(component)).append('\n');
-							else{
-								String entry = outputOreDictionaryEntry(component.getMatchingStacks());
-							
-								if(entry != null)
-									ret.append('|').append(getShapelessLocation(i, recipeItems.size())).append('=').append(entry).append('\n');
-							}
-					}
-					
-					ret.append("|O=").append(outputItemOutput(shapelessrecipe.getRecipeOutput())).append('\n');
-					ret.append("|shapeless=true\n");
-					ret.append("}}\n");
-					
-					if(iterator.hasNext())
-						ret.append('\n');
-				}
-			}
-		return ret.toString();
+		return recipes;
+	}
+
+	public String outputRecipe(IRecipe recipe){
+		StringBuilder ret = new StringBuilder("{{Cg/Crafting Table\n");
+		NonNullList<Ingredient> ingredients = recipe.getIngredients();
+
+		boolean shapeless = false;
+		int width = getWidth(recipe);
+
+		if(!(recipe instanceof IShapedRecipe))
+			shapeless = true;
+
+		for(int i = 0; i < ingredients.size(); i++){
+			Ingredient ingredient = ingredients.get(i);
+			if(ingredient == Ingredient.EMPTY || ingredient.getMatchingStacks().length == 0)
+				continue;
+
+			ret.append('|').append(Utils.getAlphabetLetter(i % width + 1)).append(i / width + 1).append('=');
+
+			if(ingredient instanceof OreIngredient)
+				ret.append(Utils.outputOreDictionaryEntry(ingredient.getMatchingStacks()));
+			else
+				ret.append(Utils.outputIngredient(ingredient));
+
+			ret.append('\n');
+		}
+
+		ret.append("|O=").append(Utils.outputItemOutput(recipe.getRecipeOutput())).append('\n');
+
+		if(shapeless){
+			ret.append("|shapeless=true\n");
+		}
+
+		return ret.append("}}\n").toString();
+	}
+
+	protected int getWidth(IRecipe recipe){
+		if(recipe instanceof IShapedRecipe)
+			return ((IShapedRecipe) recipe).getRecipeWidth();
+
+		return recipe.getIngredients().size() > 6 ? 3 : 2;
 	}
 }

--- a/src/main/java/xbony2/huesodewiki/recipe/recipes/CraftingRecipe.java
+++ b/src/main/java/xbony2/huesodewiki/recipe/recipes/CraftingRecipe.java
@@ -71,9 +71,8 @@ public class CraftingRecipe implements IWikiRecipe {
 
 		ret.append("|O=").append(Utils.outputItemOutput(recipe.getRecipeOutput())).append('\n');
 
-		if(shapeless){
+		if(shapeless)
 			ret.append("|shapeless=true\n");
-		}
 
 		return ret.append("}}\n").toString();
 	}


### PR DESCRIPTION
Less duplicate code, separated into smaller parts to make it easier to modify. I started work on an addon for more mod integration and needed to filter a specific type of recipe (Thaumcraft arcane recipes, which for some weird reason are sticked into the vanilla recipe registry), only to discover that I'd need to copy the whole method, and decided to do what I wanted to do earlier - rewrite this mess.
 
Also cleaned up a few smaller warnings (using `==` on Strings) and moved the alphabet letter helper to Utils because it was useful here too.