### PR TITLE
Config refactor

### DIFF
--- a/src/main/java/xbony2/huesodewiki/FirstSentenceCreator.java
+++ b/src/main/java/xbony2/huesodewiki/FirstSentenceCreator.java
@@ -2,8 +2,8 @@ package xbony2.huesodewiki;
 
 import static xbony2.huesodewiki.Utils.getModName;
 
-import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import xbony2.huesodewiki.config.Config;
 import xbony2.huesodewiki.infobox.parameters.TypeParameter;
 
 public class FirstSentenceCreator {
@@ -11,7 +11,7 @@ public class FirstSentenceCreator {
 		String name = itemstack.getDisplayName();
 		String modName = getModName(itemstack);
 		String type = new TypeParameter().getParameterText(itemstack);
-		String linkFix = HuesoDeWiki.linkCorrections.get(modName); //is null if there isn't a change required.
+		String linkFix = Config.linkCorrections.get(modName); //is null if there isn't a change required.
 		
 		StringBuilder ret = new StringBuilder();
 		ret.append("The '''");

--- a/src/main/java/xbony2/huesodewiki/HuesoDeWiki.java
+++ b/src/main/java/xbony2/huesodewiki/HuesoDeWiki.java
@@ -1,8 +1,6 @@
 package xbony2.huesodewiki;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.lwjgl.input.Keyboard;
 
@@ -13,7 +11,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraftforge.client.ClientCommandHandler;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -26,9 +23,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import xbony2.huesodewiki.compat.Compat;
 import xbony2.huesodewiki.command.CommandDumpStructure;
+import xbony2.huesodewiki.config.Config;
 import xbony2.huesodewiki.recipe.RecipeCreator;
 
-@Mod(modid = HuesoDeWiki.MODID, version = HuesoDeWiki.VERSION, clientSideOnly = true)
+@Mod(modid = HuesoDeWiki.MODID, version = HuesoDeWiki.VERSION, clientSideOnly = true, guiFactory = "xbony2.huesodewiki.config.HuesoGuiConfigFactory")
 public class HuesoDeWiki {
 	public static final String MODID = "huesodewiki";
 	public static final String VERSION = "@VERSION@";
@@ -40,16 +38,6 @@ public class HuesoDeWiki {
 	
 	public static KeyBinding copyNameKey;
 	private boolean isCopyNameKeyDown = false;
-	
-	public static boolean use2SpaceStyle;
-	public static boolean useStackedCategoryStyle;
-	public static boolean printOutputToLog;
-	
-	public static Map<String, String> nameCorrections = new HashMap<>();
-	public static Map<String, String> linkCorrections = new HashMap<>();
-	
-	public static final String[] DEFAULT_NAME_CORRECTIONS = new String[]{"Iron Chest", "Iron Chests", "Minecraft", "Vanilla", "Thermal Expansion", "Thermal Expansion 5", "Pressurized Defense", "Pressurized Defence"};
-	public static final String[] DEFAULT_LINK_CORRECTIONS = new String[]{"Esteemed Innovation", "Esteemed Innovation (mod)"};
 
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event){
@@ -58,23 +46,9 @@ public class HuesoDeWiki {
 		copyNameKey = new KeyBinding("key.copyname", Keyboard.KEY_APOSTROPHE, "key.categories.huesodewiki");
 		ClientRegistry.registerKeyBinding(copyNameKey);
 		MinecraftForge.EVENT_BUS.register(new RenderTickEventEventHanlder());
-		
-		Configuration config = new Configuration(new File(event.getModConfigurationDirectory(), "HuesoDeWiki.cfg"));
-		config.load();
-		use2SpaceStyle = config.getBoolean("Use2SpaceStyle", "Main", false, "Use \"2spacestyle\"- put an extra space in headers (like \"== Recipe ==\", as vs \"==Recipe==\").");
-		useStackedCategoryStyle = config.getBoolean("UseStackedCategoryStyle", "Main", false, "Use \"stacked\" category style– put each category on its own line.");
-		String[] nameCorrections = config.getStringList("NameCorrections", "Main", DEFAULT_NAME_CORRECTIONS, "Name fixes. Is a map- first entry is the mod's internal name, second is the FTB Wiki's name.");
-		String[] linkCorrections = config.getStringList("LinkCorrections", "Main", DEFAULT_LINK_CORRECTIONS, "Link fixes. Is a map- first entry is the mod's name, second is the FTB Wiki's page.");
-		printOutputToLog = config.getBoolean("PrintOutputToLog", "Main", false, "Enable to print the generated output to the console log- for debugging purposes or as a workaround for OpenJDK bug JDK-8179547 on Linux");
-		
-		for(int i = 0; i < nameCorrections.length - 1; i += 2)
-			this.nameCorrections.put(nameCorrections[i], nameCorrections[i + 1]);
-		
-		for(int i = 0; i < linkCorrections.length - 1; i += 2)
-			this.nameCorrections.put(linkCorrections[i], linkCorrections[i + 1]);
-		
-		config.save();
-		
+
+		Config.initConfig(new File(event.getModConfigurationDirectory(), "HuesoDeWiki.cfg"));
+
 		Compat.preInit();
 	}
 	

--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -18,6 +18,7 @@ import net.minecraft.util.NonNullList;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.ModContainer;
 import net.minecraftforge.oredict.OreDictionary;
+import xbony2.huesodewiki.config.Config;
 
 public class Utils {
 	public static String getModName(String modid){
@@ -27,7 +28,7 @@ public class Utils {
 			return "Vanilla";
 		else{
 			String modName = container.getName();
-			return HuesoDeWiki.nameCorrections.get(modName) != null ? HuesoDeWiki.nameCorrections.get(modName) : modName;
+			return Config.nameCorrections.get(modName) != null ? Config.nameCorrections.get(modName) : modName;
 		}
 	}
 	
@@ -153,7 +154,7 @@ public class Utils {
 	public static void copyString(String toCopy){
 		Toolkit.getDefaultToolkit().getSystemClipboard().setContents(new StringSelection(toCopy), null);
 		
-		if(HuesoDeWiki.printOutputToLog) 
+		if(Config.printOutputToLog) 
 			HuesoDeWiki.LOGGER.info("Generated text:\n" + toCopy);
 	}
 

--- a/src/main/java/xbony2/huesodewiki/category/CategoryCreator.java
+++ b/src/main/java/xbony2/huesodewiki/category/CategoryCreator.java
@@ -18,7 +18,7 @@ import net.minecraft.item.ItemShears;
 import net.minecraft.item.ItemSpade;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemSword;
-import xbony2.huesodewiki.HuesoDeWiki;
+import xbony2.huesodewiki.config.Config;
 import xbony2.huesodewiki.api.category.BasicCategory;
 import xbony2.huesodewiki.api.category.BasicInstanceOfCategory;
 import xbony2.huesodewiki.api.category.ICategory;
@@ -49,6 +49,6 @@ public class CategoryCreator {
 		
 		categories.stream().filter((category) -> category.canAdd(itemstack)).forEach((category) -> categoryStrings.add("[[Category:" + category.getCategoryName(itemstack) + "]]"));
 
-		return Joiner.on(HuesoDeWiki.useStackedCategoryStyle ? "\n" : "").join(categoryStrings);
+		return Joiner.on(Config.useStackedCategoryStyle ? "\n" : "").join(categoryStrings);
 	}
 }

--- a/src/main/java/xbony2/huesodewiki/config/Config.java
+++ b/src/main/java/xbony2/huesodewiki/config/Config.java
@@ -1,0 +1,89 @@
+package xbony2.huesodewiki.config;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import xbony2.huesodewiki.HuesoDeWiki;
+
+public class Config {
+
+	private static final String[] DEFAULT_NAME_CORRECTIONS = new String[]{"Iron Chest", "Iron Chests", "Minecraft", "Vanilla", "Thermal Expansion", "Thermal Expansion 5", "Pressurized Defense", "Pressurized Defence", "Thaumcraft", "Thaumcraft 6"};
+	private static final String[] DEFAULT_LINK_CORRECTIONS = new String[]{"Esteemed Innovation", "Esteemed Innovation (mod)"};
+
+	public static boolean use2SpaceStyle;
+	public static boolean useStackedCategoryStyle;
+	public static boolean printOutputToLog;
+
+	public static Map<String, String> nameCorrections = new HashMap<>();
+	public static Map<String, String> linkCorrections = new HashMap<>();
+
+	static Configuration config;
+
+	private static final int CONFIG_VERSION = 1;
+
+	public static void initConfig(File file){
+		config = new Configuration(file, String.valueOf(CONFIG_VERSION));
+		config.load();
+
+		readConfig();
+		updateConfig();
+		
+		MinecraftForge.EVENT_BUS.register(Config.class);
+	}
+
+	private static void readConfig(){
+		use2SpaceStyle = config.getBoolean("Use2SpaceStyle", "Main", false, "Use \"2spacestyle\"- put an extra space in headers (like \"== Recipe ==\", as vs \"==Recipe==\").");
+		useStackedCategoryStyle = config.getBoolean("UseStackedCategoryStyle", "Main", false, "Use \"stacked\" category style– put each category on its own line.");
+		String[] nameCorrections = config.getStringList("NameCorrections", "Main", DEFAULT_NAME_CORRECTIONS, "Name fixes. Is a map- first entry is the mod's internal name, second is the FTB Wiki's name.");
+		String[] linkCorrections = config.getStringList("LinkCorrections", "Main", DEFAULT_LINK_CORRECTIONS, "Link fixes. Is a map- first entry is the mod's name, second is the FTB Wiki's page.");
+		printOutputToLog = config.getBoolean("PrintOutputToLog", "Main", false, "Enable to print the generated output to the console log- for debugging purposes or as a workaround for OpenJDK bug JDK-8179547 on Linux");
+
+		for(int i = 0; i < nameCorrections.length - 1; i += 2)
+			Config.nameCorrections.put(nameCorrections[i], nameCorrections[i + 1]);
+
+		for(int i = 0; i < linkCorrections.length - 1; i += 2)
+			Config.nameCorrections.put(linkCorrections[i], linkCorrections[i + 1]);
+
+		if(config.hasChanged())
+			config.save();
+	}
+
+	private static void updateConfig(){
+		int version;
+
+		try {
+			if(config.getLoadedConfigVersion() == null)
+				version = 0;
+			else
+				version = Integer.parseInt(config.getLoadedConfigVersion());
+		}catch(NumberFormatException e){
+			HuesoDeWiki.LOGGER.error("Invalid config version!", e);
+			return;
+		}
+
+		if(version > CONFIG_VERSION){
+			HuesoDeWiki.LOGGER.error("Future config version detected!");
+			return;
+		}
+
+		if(version <= 0){
+			HuesoDeWiki.LOGGER.info("Updating HuesoDeWiki config");
+
+			HuesoDeWiki.LOGGER.info("Resetting name corrections to default");
+			config.get("Main", "NameCorrections", DEFAULT_NAME_CORRECTIONS).set(DEFAULT_NAME_CORRECTIONS);
+
+			readConfig();
+		}
+	}
+
+	@SubscribeEvent
+	public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event){
+		if(HuesoDeWiki.MODID.equals(event.getModID()))
+			readConfig();
+	}
+}

--- a/src/main/java/xbony2/huesodewiki/config/HuesoGuiConfig.java
+++ b/src/main/java/xbony2/huesodewiki/config/HuesoGuiConfig.java
@@ -1,0 +1,26 @@
+package xbony2.huesodewiki.config;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.common.config.ConfigElement;
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.client.config.GuiConfig;
+import net.minecraftforge.fml.client.config.IConfigElement;
+import xbony2.huesodewiki.HuesoDeWiki;
+
+//Adapted from Quat's mods, who adapted it from Choonster's TestMod3, who adapted it from Ender IO.
+public class HuesoGuiConfig extends GuiConfig {
+
+	public HuesoGuiConfig(GuiScreen parent) {
+		super(parent, getConfigElements(), HuesoDeWiki.MODID, false, false, "HuesoDeWiki Config");
+	}
+
+	private static List<IConfigElement> getConfigElements() {
+		Configuration c = Config.config;
+
+		return c.getCategoryNames().stream().filter(name -> !c.getCategory(name).isChild()).map(name -> new ConfigElement(c.getCategory(name).setLanguageKey(HuesoDeWiki.MODID + ".config." + name))).collect(Collectors.toList());
+	}
+
+}

--- a/src/main/java/xbony2/huesodewiki/config/HuesoGuiConfig.java
+++ b/src/main/java/xbony2/huesodewiki/config/HuesoGuiConfig.java
@@ -10,17 +10,18 @@ import net.minecraftforge.fml.client.config.GuiConfig;
 import net.minecraftforge.fml.client.config.IConfigElement;
 import xbony2.huesodewiki.HuesoDeWiki;
 
-//Adapted from Quat's mods, who adapted it from Choonster's TestMod3, who adapted it from Ender IO.
+/**
+ * Adapted from Quat's mods, who adapted it from Choonster's TestMod3, who adapted it from Ender IO.
+ */
 public class HuesoGuiConfig extends GuiConfig {
 
-	public HuesoGuiConfig(GuiScreen parent) {
+	public HuesoGuiConfig(GuiScreen parent){
 		super(parent, getConfigElements(), HuesoDeWiki.MODID, false, false, "HuesoDeWiki Config");
 	}
 
-	private static List<IConfigElement> getConfigElements() {
+	private static List<IConfigElement> getConfigElements(){
 		Configuration c = Config.config;
 
 		return c.getCategoryNames().stream().filter(name -> !c.getCategory(name).isChild()).map(name -> new ConfigElement(c.getCategory(name).setLanguageKey(HuesoDeWiki.MODID + ".config." + name))).collect(Collectors.toList());
 	}
-
 }

--- a/src/main/java/xbony2/huesodewiki/config/HuesoGuiConfigFactory.java
+++ b/src/main/java/xbony2/huesodewiki/config/HuesoGuiConfigFactory.java
@@ -1,0 +1,28 @@
+package xbony2.huesodewiki.config;
+
+import java.util.Set;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.IModGuiFactory;
+
+public class HuesoGuiConfigFactory implements IModGuiFactory {
+
+	@Override
+	public void initialize(Minecraft minecraftInstance){}
+
+	@Override
+	public boolean hasConfigGui(){
+		return true;
+	}
+
+	@Override
+	public GuiScreen createConfigGui(GuiScreen parentScreen){
+		return new HuesoGuiConfig(parentScreen);
+	}
+
+	@Override
+	public Set<RuntimeOptionCategoryElement> runtimeGuiCategories(){
+		return null;
+	}
+}

--- a/src/main/java/xbony2/huesodewiki/recipe/RecipeCreator.java
+++ b/src/main/java/xbony2/huesodewiki/recipe/RecipeCreator.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.minecraft.item.ItemStack;
-import xbony2.huesodewiki.HuesoDeWiki;
+import xbony2.huesodewiki.config.Config;
 import xbony2.huesodewiki.api.IWikiRecipe;
 import xbony2.huesodewiki.recipe.recipes.*;
 
@@ -28,6 +28,6 @@ public class RecipeCreator {
 		
 		if(ret.toString().length() < 1)
 			return "";
-		return (HuesoDeWiki.use2SpaceStyle ? "== Recipe ==" : "==Recipe==") + "\n" + ret.toString() + "\n";
+		return (Config.use2SpaceStyle ? "== Recipe ==" : "==Recipe==") + "\n" + ret.toString() + "\n";
 	}
 }


### PR DESCRIPTION
* Moved configuration stuff to its own package
* Added an in-game config menu (available from the mod list menu)
* Added automatic adjustment of changed existing configs
* Added Thaumcraft 6 to name overrides (and used the above system to apply it automatically to old configs to avoid making everyone delete the config)

On a change of a default value, `Config#updateConfig` will need to be adjusted.

I tested that this works, the config updating only is done if the config file already exists and doesn't have a version/has an old version, and the GUI works as well.