### PR TITLE
Fix the method for getting a blockstate not taking metadata into account

### DIFF
--- a/src/main/java/xbony2/huesodewiki/Utils.java
+++ b/src/main/java/xbony2/huesodewiki/Utils.java
@@ -114,12 +114,15 @@ public class Utils {
 		return ret;
 	}
 
-	@SuppressWarnings("static-access")
+	/**
+	 * @param itemstack Stack to convert into blockstate
+	 * @return State corresponding to the item, taking metadata into account
+	 */
+	@SuppressWarnings("deprecation")
 	public static IBlockState stackToBlockState(ItemStack itemstack){
 		Block b = Block.getBlockFromItem(itemstack.getItem());
 		try {
-			//return b.getStateFromMeta(itemstack.getMetadata());
-			return b.getStateById(Item.getIdFromItem(itemstack.getItem()));
+			return b.getStateFromMeta(itemstack.getMetadata());
 		}catch(Exception e){
 			return b.getDefaultState();
 		}


### PR DESCRIPTION
I wired up a little logging into your replacement and got this result on jungle planks.
![image](https://user-images.githubusercontent.com/26120076/46518586-3cb4a280-c875-11e8-9cc5-1cb6e7cedf15.png)
Your code is effectively equal to getting the default state, and in the event of an exception... getting the default state again. The whole point of me making this method is metadata sensitivity.

By the way, instead of suppressing static access warnings from your IDE... Why not just, like, replace the `b` with `Block`?
